### PR TITLE
clearance settengs for TQFP 64 pin 10x10 footprint

### DIFF
--- a/TQFP-64_1EP_10x10mm_Pitch0.5mm.kicad_mod
+++ b/TQFP-64_1EP_10x10mm_Pitch0.5mm.kicad_mod
@@ -1,8 +1,6 @@
 (module TQFP-64_1EP_10x10mm_Pitch0.5mm (layer F.Cu) (tedit 58CC9A48)
   (descr "64-Lead Plastic Thin Quad Flatpack (PT) - 10x10x1 mm Body, 2.00 mm Footprint [TQFP] thermal pad")
   (tags "QFP 0.5 ")
-  (solder_mask_margin -1.8)
-  (solder_paste_margin -1.8)
   (attr smd)
   (fp_text reference REF** (at 0 -7.45) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))


### PR DESCRIPTION
Fix for problem reported over at the info forum:
https://forum.kicad.info/t/footprints-soldermask-is-missing/7371